### PR TITLE
Fixing Issue https://github.com/aqw/xbmc-gamepass/issues/395

### DIFF
--- a/pigskin/pigskin.py
+++ b/pigskin/pigskin.py
@@ -681,6 +681,7 @@ class pigskin(object):
     def parse_shows(self):
         """Dynamically parse the NFL Network shows into a dict."""
         show_dict = {}
+        self.episode_list = []
 
         # NFL Network shows
         url = self.config['modules']['API']['NETWORK_PROGRAMS']


### PR DESCRIPTION
I am sure there are more elegant ways to fix this issue but this small changes do the trick.
As the parsing command is only executed if someone wants a new List of NFL episodes i think its a good start to make sure the List is empty.
