### PR TITLE
Fixing an Gamepass Europe Backend Change

### DIFF
--- a/pigskin/europe/video.py
+++ b/pigskin/europe/video.py
@@ -229,7 +229,7 @@ class video(object):
         }
         for vs in akamai_xml.iter('videoSource'):
             try:
-                vs_format = vs.attrib['format'].lower()
+                vs_format = vs.attrib['name'].lower()
                 vs_url = vs.find('uri').text
             except (KeyError, AttributeError):
                 continue


### PR DESCRIPTION
This fix is not tested because i have not much time at the moment.
But i noticed that NFL Europe Change theire format a bit.
Now its looks like <videoSource format="HLS-V3" name="Chromecast" offset="0:00:00"> .
In previous Versions it was something like <videoSource format="Chromecast" offset="0:00:00"> .