### PR TITLE
Fixed missing Content-Type header for video URL request

### DIFF
--- a/pigskin/europe/video.py
+++ b/pigskin/europe/video.py
@@ -221,7 +221,8 @@ class video(object):
             payload = self._build_processing_url_payload(video_id, vs_url)
 
             try:
-                r = self._store.s.post(url=processing_url, data=payload)
+                h = {'Content-Type': 'application/json'}
+                r = self._store.s.post(url=processing_url, data=payload, headers=h)
                 #self._log_request(r)
                 data = r.json()
                 content_url = data['ContentUrl']


### PR DESCRIPTION
Current NFL GamePass API gives an error code 415 in case the Content-Type is not set correctly. I added the correct header in this patch.